### PR TITLE
Fix login example on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ const Login = () => {
         Authorization: "Bearer " + DIDT,
       }),
     });
+    
+    let data = await res.json();
 
     /* If the user is authorized, return an object containing the user properties (issuer, publicAddress, email) */
     /* Else, the login was not successful and return false */


### PR DESCRIPTION
The Login example wasn't calling `.json()` after getting the response. This may hard to figure out for unexperienced developers.