### PR TITLE
fix: fixes the callback query checks

### DIFF
--- a/pages/callback.js
+++ b/pages/callback.js
@@ -18,7 +18,7 @@ const Callback = () => {
         })
       );
     /* if `provider` is in our query params, the user is logging in with a social provider */
-    magic && router.query.provider ? finishSocialLogin() : finishEmailRedirectLogin();
+    magic && (router.query.provider ? finishSocialLogin() : finishEmailRedirectLogin());
   }, [magic, router.query]);
 
   const finishSocialLogin = async () => {


### PR DESCRIPTION
The previous if statement resulted in the emailRedirectLogin being called without magic link being defined. eg;

```js
if(magic && router.query.provider) return finishSocialLogin()
else return finishEmailRedirectLogin()
```

I should instead read:
```js
if(magic){
   if(router.query.provider) return finishSocialLogin()
   else return finishEmailRedirectLogin()
}
```